### PR TITLE
added functionality to add the encoding of content displayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.venv
 build/
 develop-eggs/
 dist/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Render the HTML content in a web browser.
 - `browser` (str, optional): The name of the web browser to use (i.e., "chrome", "safari").
   If provided, the HTML content will be opened using the specified browser.
   If not provided or set to None, the default browser will be used.
+- `encoding` (str, optional) the encoding method you want to encode your content
+  If not provided, the default option will be chosen 
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# render_html
+# render_html_v2
 
-`render_html` is a Python library that provides a simple way to render HTML content in a web browser. 
+`render_html_v2` is a fork of the library render_html by bmika1 found here 
+https://github.com/bmika1/render-html it keeps the api the same but gives you the option to include your own encoding.
 It allows you to open HTML content directly from a string or save it to a file and open it from the file.
 You can also specify the name of a browser to use a non-default browser. Please refer to [webbrowser documentation](https://docs.python.org/3/library/webbrowser.html) for the complete list of predefined browsers.
 This library is especially useful for quickly visualizing and testing HTML content in a web browser environment.
 
 ## Installation
 
-You can install `render_html` using pip:
+You can install `render_html_v2` using pip:
 
-pip install render-html
+pip install render-html-v2
 
 NOTE: the library requires Python 3.10 or newer
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ren(html_content)
 
 ## Documentation
 
-### `render_in_browser(html_string, save_path=None, browser=None)`
+### `render_in_browser(html_string, save_path=None, browser=None, encoding=None)`
 
 Render the HTML content in a web browser.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "render_html"
-version = "1.0.1"
+name = "render_html_v2"
+version = "1.0.0"
 authors = [
-  { name="Bartlomiej Mika", email="bmika1@icloud.com" },
+  { name="Emmanuel Bastidas", email="EmmanuelBastidas@tutanota.com" },
 ]
 description = "Python library that provides a simple way to render HTML content in a web browser."
 readme = "README.md"
@@ -18,5 +18,5 @@ classifiers = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/bmika1/render-html"
-"Bug Tracker" = "https://github.com/bmika1/render-html/issues"
+"Homepage" = "https://github.com/ank634/render-html"
+"Bug Tracker" = "https://github.com/ank634/render-html/issues"

--- a/src/render_html/_renderer.py
+++ b/src/render_html/_renderer.py
@@ -31,7 +31,7 @@ def _open_in_browser(file_path: str, browser: str | None = None) -> None:
     client.open_new(file_path)
 
 
-def _handle_open_from_temp(html_string: str, browser: str | None = None) -> None:
+def _handle_open_from_temp(html_string: str, browser: str | None = None, encoding: str | None = None) -> None:
     """
     Handle opening HTML content from a temporary file in a web browser.
 
@@ -40,12 +40,14 @@ def _handle_open_from_temp(html_string: str, browser: str | None = None) -> None
         browser (str | None, optional): The web browser to use (i.e. "chrome", "safari").
             If provided, the HTML content will be opened using the specified browser.
             If not provided or set to None, the default browser will be used.
+        encoding (str | None, optional): The encoding to use when writing to the file.
+            If not provided or set to None, the default encoding will be used.
     """
     # Set delete parameter depending on the platform
     autodelete = platform.system() != "Windows"
 
     with tempfile.NamedTemporaryFile(
-        mode="w", delete=autodelete, suffix=".html"
+        mode="w", delete=autodelete, suffix=".html", encoding=encoding
     ) as tmp_file:
         tmp_file.write(html_string)
         file_path = tmp_file.name
@@ -61,7 +63,8 @@ def _handle_open_from_temp(html_string: str, browser: str | None = None) -> None
 
 
 def _handle_open_from_regular_file(
-    html_string: str, save_path: str, browser: str | None = None
+    html_string: str, save_path: str, browser: str | None = None,
+    encoding: str | None = None
 ) -> None:
     """
     Handle opening HTML content from a regular file in a web browser.
@@ -72,14 +75,17 @@ def _handle_open_from_regular_file(
         browser (str | None, optional): The executable path of the web browser to use.
             If provided, the HTML content will be opened using the specified browser.
             If not provided or set to None, the default browser will be used.
+        encoding (str | None, optional): The encoding to use when writing to the file.
+            If not provided or set to None, the default encoding will be used.
     """
-    with open(save_path, "w") as f:
+    with open(save_path, "w", encoding=encoding) as f:
         f.write(html_string)
     _open_in_browser(save_path, browser)
 
 
 def render_in_browser(
-    html_string: str, save_path: str | None = None, browser: str | None = None
+    html_string: str, save_path: str | None = None, browser: str | None = None,
+    encoding: str | None = None
 ) -> None:
     """
     Render the HTML content in a web browser.
@@ -95,8 +101,10 @@ def render_in_browser(
         browser (str | None, optional): The web browser to use (i.e. "chrome", "safari").
             If provided, the HTML content will be opened using the specified browser.
             If not provided or set to None, the default browser will be used.
+        encoding (str | None, optional): The encoding to use when writing to the file.
+            If not provided or set to None, the default encoding will be used.
     """
     if save_path:
-        _handle_open_from_regular_file(html_string, save_path, browser)
+        _handle_open_from_regular_file(html_string, save_path, browser, encoding)
     else:
-        _handle_open_from_temp(html_string, browser)
+        _handle_open_from_temp(html_string, browser, encoding)

--- a/tests/test_render_html.py
+++ b/tests/test_render_html.py
@@ -15,8 +15,9 @@ class RendererTestCase(unittest.TestCase):
         cls.html_string = "<html><body><h1>Hello, World!</h1></body></html>"
         cls.save_path = "/path/to/save/file.html"
         cls.temp_path = "/path/to/temp/file.html"
+        cls.selected_encoding = "utf-8"
 
-    def test_handle_open_from_regular_file(self):
+    def test_handle_open_from_regular_file_default_encoding(self):
         with patch("builtins.open", create=True) as mock_open, patch(
             "webbrowser.open_new"
         ) as mock_webbrowser_open:
@@ -24,11 +25,25 @@ class RendererTestCase(unittest.TestCase):
             mock_file.name = self.save_path
             mock_open.return_value.__enter__.return_value = mock_file
             _handle_open_from_regular_file(self.html_string, self.save_path)
-            mock_open.assert_called_once_with(self.save_path, "w")
+            mock_open.assert_called_once_with(self.save_path, "w", encoding = None)
             mock_file.write.assert_called_once_with(self.html_string)
             mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
 
-    def test_handle_open_from_temp(self):
+    
+    def test_handle_open_from_regular_file_selected_encoding(self):
+        with patch("builtins.open", create=True) as mock_open, patch(
+            "webbrowser.open_new"
+        ) as mock_webbrowser_open:
+            mock_file = MagicMock()
+            mock_file.name = self.save_path
+            mock_open.return_value.__enter__.return_value = mock_file
+            _handle_open_from_regular_file(self.html_string, self.save_path, encoding = self.selected_encoding)
+            mock_open.assert_called_once_with(self.save_path, "w", encoding = self.selected_encoding)
+            mock_file.write.assert_called_once_with(self.html_string)
+            mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
+
+
+    def test_handle_open_from_temp_default_encoding(self):
         with patch("tempfile.NamedTemporaryFile", create=True) as mock_tempfile, patch(
             "webbrowser.open_new"
         ) as mock_webbrowser_open:
@@ -36,11 +51,24 @@ class RendererTestCase(unittest.TestCase):
             mock_tempfile.return_value.__enter__.return_value = mock_file
             mock_file.name = self.temp_path
             _handle_open_from_temp(self.html_string)
-            mock_tempfile.assert_called_once_with(mode="w", delete=True, suffix=".html")
+            mock_tempfile.assert_called_once_with(mode="w", delete=True, suffix=".html", encoding = None)
             mock_file.write.assert_called_once_with(self.html_string)
             mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
 
-    def test_render_in_browser_save_path(self):
+
+    def test_handle_open_from_temp_selected_encoding(self):
+        with patch("tempfile.NamedTemporaryFile", create=True) as mock_tempfile, patch(
+            "webbrowser.open_new"
+        ) as mock_webbrowser_open:
+            mock_file = MagicMock()
+            mock_tempfile.return_value.__enter__.return_value = mock_file
+            mock_file.name = self.temp_path
+            _handle_open_from_temp(self.html_string, encoding = self.selected_encoding)
+            mock_tempfile.assert_called_once_with(mode="w", delete=True, suffix=".html", encoding = self.selected_encoding)
+            mock_file.write.assert_called_once_with(self.html_string)
+            mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
+
+    def test_render_in_browser_save_path_default_encoding(self):
         with patch("builtins.open", create=True) as mock_open, patch(
             "webbrowser.open_new"
         ) as mock_webbrowser_open:
@@ -48,11 +76,24 @@ class RendererTestCase(unittest.TestCase):
             mock_file.name = self.save_path
             mock_open.return_value.__enter__.return_value = mock_file
             render_in_browser(self.html_string, save_path=self.save_path)
-            mock_open.assert_called_once_with(self.save_path, "w")
+            mock_open.assert_called_once_with(self.save_path, "w", encoding = None)
             mock_file.write.assert_called_once_with(self.html_string)
             mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
 
-    def test_render_in_browser_temp_file(self):
+
+    def test_render_in_browser_save_path_selected_encoding(self):
+        with patch("builtins.open", create=True) as mock_open, patch(
+            "webbrowser.open_new"
+        ) as mock_webbrowser_open:
+            mock_file = MagicMock()
+            mock_file.name = self.save_path
+            mock_open.return_value.__enter__.return_value = mock_file
+            render_in_browser(self.html_string, save_path=self.save_path, encoding=self.selected_encoding)
+            mock_open.assert_called_once_with(self.save_path, "w", encoding = self.selected_encoding)
+            mock_file.write.assert_called_once_with(self.html_string)
+            mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
+
+    def test_render_in_browser_temp_file_default_encoding(self):
         with patch("tempfile.NamedTemporaryFile", create=True) as mock_tempfile, patch(
             "webbrowser.open_new"
         ) as mock_webbrowser_open:
@@ -60,7 +101,20 @@ class RendererTestCase(unittest.TestCase):
             mock_tempfile.return_value.__enter__.return_value = mock_file
             mock_file.name = self.temp_path
             render_in_browser(self.html_string)
-            mock_tempfile.assert_called_once_with(mode="w", delete=True, suffix=".html")
+            mock_tempfile.assert_called_once_with(mode="w", delete=True, suffix=".html", encoding = None)
+            mock_file.write.assert_called_once_with(self.html_string)
+            mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
+
+
+    def test_render_in_browser_temp_file_selected_encoding(self):
+        with patch("tempfile.NamedTemporaryFile", create=True) as mock_tempfile, patch(
+            "webbrowser.open_new"
+        ) as mock_webbrowser_open:
+            mock_file = MagicMock()
+            mock_tempfile.return_value.__enter__.return_value = mock_file
+            mock_file.name = self.temp_path
+            render_in_browser(self.html_string, encoding=self.selected_encoding)
+            mock_tempfile.assert_called_once_with(mode="w", delete=True, suffix=".html", encoding = self.selected_encoding)
             mock_file.write.assert_called_once_with(self.html_string)
             mock_webbrowser_open.assert_called_once_with(f"file:///{mock_file.name}")
 


### PR DESCRIPTION
# Problem
Currently when calling render in browser the html string is being written to the file using whatever the default encoding is for the operating system. This is an issue particularly with windows since many times the default is not utf-8 but instead cp1252 when writing to a file
https://stackoverflow.com/questions/36303919/what-encoding-does-open-use-by-default.
So if a user wants to encode the contents in utf-8 it becomes a hassle.

# Solution
I have updated the api to include the encoding. So now the user can write to the file in any encoding the deem fit.

 